### PR TITLE
Fix 'search_opts' error with backup delete command

### DIFF
--- a/cinderclient/v1/volume_backups.py
+++ b/cinderclient/v1/volume_backups.py
@@ -58,7 +58,7 @@ class VolumeBackupManager(base.ManagerWithFind):
         """
         return self._get("/backups/%s" % backup_id, "backup")
 
-    def list(self, detailed=True):
+    def list(self, detailed=True, search_opts=None):
         """Get a list of all volume backups.
 
         :rtype: list of :class:`VolumeBackup`

--- a/cinderclient/v2/volume_backups.py
+++ b/cinderclient/v2/volume_backups.py
@@ -58,7 +58,7 @@ class VolumeBackupManager(base.ManagerWithFind):
         """
         return self._get("/backups/%s" % backup_id, "backup")
 
-    def list(self, detailed=True):
+    def list(self, detailed=True, search_opts=None):
         """Get a list of all volume backups.
 
         :rtype: list of :class:`VolumeBackup`


### PR DESCRIPTION
The following error message is yield when we try to
backup volume which is not present.

ERROR: list() got an unexpected keyword argument 'search_opts'

This is from findall() method in the
cinderclient.base.ManagerWithFind class.

When cinderclient get a specific resource, it use the findall() method.

The error will yields which list() in
VolumeEncryptionTypeManager did not have.

Change-Id: Iffe568c6d2de41b8e24658f3a54f2861e2f7db31
Closes-Bug: #1282324
Related-Bug: #1248519
